### PR TITLE
Fix building macOS target

### DIFF
--- a/Plugins/JPushBinding.cs
+++ b/Plugins/JPushBinding.cs
@@ -1,3 +1,4 @@
+#if UNITY_ANDROID || UNITY_IOS
 using UnityEngine;
 using System;
 using System.Collections;
@@ -808,3 +809,4 @@ namespace JPush
 #endif
     }
 }
+#endif


### PR DESCRIPTION
Line 277, in `FilterValidTags`, `reJson` is only declared for iOS or Android, so the whole file is causing build errors for a macOS target. Unity hardly lets us choose which files to build for which target, so we need a macro to fix the compilation.