### PR TITLE
变量 reJson 赋初始值

### DIFF
--- a/Plugins/JPushBinding.cs
+++ b/Plugins/JPushBinding.cs
@@ -266,7 +266,7 @@ namespace JPush
         public static List<string> FilterValidTags(List<string> jsonTags)
         {
             string tagsJsonStr = JsonHelper.ToJson(jsonTags);
-            string reJson;
+            string reJson = null;
 
             #if UNITY_ANDROID
             reJson = _plugin.Call<string>("filterValidTags", tagsJsonStr);


### PR DESCRIPTION
修复 Assets\Plugins\JPushBinding.cs(276,25): error CS0165: Use of unassigned local variable 'reJson' 错误。